### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           # Version of the OCaml compiler to initialise
           ocaml-version: 4.12.0
-      - run: opam install --yes cohttp-lwt-unix cohttp-async lambdasoup ocamlfind yojson lwt_ssl
+      - run: opam install --yes ocamlfind core.v0.14.1 cohttp-lwt-unix cohttp-async lambdasoup yojson lwt_ssl
 
       # BUILD
       - name: build


### PR DESCRIPTION
Fix for https://github.com/haruki-sugarsun/confluenece_site_converter/issues/5 by specifying v0.14.1, which works well locally.